### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 51Degrees IP Intelligence API
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_campaign=c_open_source&utm_content=readme_main "Data rewards the curious") **IP Intelligence in GO**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-go&utm_content=readme.md&utm_term=51degrees-ip-intelligence-api "Data rewards the curious") **IP Intelligence in GO**
 
 ## Introduction
 
@@ -23,7 +23,7 @@ This Go version contains the following packages:
 ### Data File Setup
 
 To process IP addresses, you will need to use the 51Degrees data file.
-See [ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data) repo for the instructions on how to get a Lite data file or [contact us](https://51degrees.com/contact-us) to get an Enterprise data file.
+See [ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data) repo for the instructions on how to get a Lite data file or [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-go&utm_content=readme.md&utm_term=data-file-setup) to get an Enterprise data file.
 
 ### Windows Configuration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # 51Degrees Ip Intelligence API Examples
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_campaign=c_open_source&utm_content=readme_main "Data rewards the curious")
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-go&utm_content=examples-readme.md&utm_term=51degrees-ip-intelligence-api-examples "Data rewards the curious")
 **IP Intelligence Go Examples**
 
 ## Introduction

--- a/examples/update_polling_interval/main.go
+++ b/examples/update_polling_interval/main.go
@@ -60,7 +60,7 @@ config := ipi_interop.NewConfigIpi(ipi_interop.InMemory)
 		// 3. No license key is required when using a custom URL
 		// For production use, you will eventually need to use a Distributor service and
 		// license key to keep your data file updated.
-		// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us
+		// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-go&utm_content=examples-update_polling_interval-main.go&utm_term=top
 		ipi_onpremise.WithLicenseKey(params.LicenseKey),
 
 		// WithAutoUpdate enables or disables auto update
@@ -209,7 +209,7 @@ func main() {
 				// 3. No license key is required when using a custom URL
 				// For production use, you will eventually need to use a Distributor service and
 				// license key to keep your data file updated.
-				// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us
+				// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-go&utm_content=examples-update_polling_interval-main.go&utm_term=main
 				ipi_onpremise.WithLicenseKey(params.LicenseKey),
 
 				// Enable automatic updates.

--- a/ipi_interop/ip-intelligence-cxx.c
+++ b/ipi_interop/ip-intelligence-cxx.c
@@ -17688,7 +17688,7 @@ static StatusMessage messages[] = {
 		"pool. Another way to avoid this is by using an in-memory "
 		"configuration, which avoids using file handles completely, and "
 		"removes any limit on concurrency. For info see "
-		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html?utm_source=code&utm_medium=comment&utm_campaign=common-cxx&utm_content=status.c&utm_term=insufficient_handles"},
+		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html?utm_source=code&utm_medium=comment&utm_campaign=ip-intelligence-go&utm_content=ipi_interop-ip-intelligence-cxx.c&utm_term=insufficient_handles"},
 	{ COLLECTION_INDEX_OUT_OF_RANGE,
 		"Index used to retrieve an item from a collection was out of range." },
 	{ COLLECTION_OFFSET_OUT_OF_RANGE,


### PR DESCRIPTION
Tags navigational 51degrees.com links with the standard UTM vocabulary so the Content Team can trace traffic to its exact source.

- utm_source: `github` for markdown, `code` for source comments.
- utm_medium: `readme` for README files, `example` for files under examples/, `comment` for library source.
- utm_campaign: `ip-intelligence-go`.
- utm_content: file path slug; utm_term: location within the file.

Scope:
- README.md (logo image query normalised to the new scheme; contact-us link tagged).
- examples/README.md (logo image).
- examples/update_polling_interval/main.go (two contact-us comment links, distinct terms for the file-scope doc comment and the main function).
- ipi_interop/ip-intelligence-cxx.c (amalgamated C library: user-visible status message link retagged from the common-cxx campaign to this repo).

Copyright headers and third-party links are untouched. A second commit adds the `UTM link lint` workflow that runs scripts/utm-lint.ps1 from common-ci.