### PR TITLE
Expose confidence weights for all IPI properties

### DIFF
--- a/ipi_interop/results_ipi.go
+++ b/ipi_interop/results_ipi.go
@@ -34,6 +34,11 @@ import (
 // uint16Max represents the maximum value of a uint16 converted to a float64.
 var uint16Max = float64(C.UINT16_MAX)
 
+// maxWeighting is the maximum value of a header's rawWeighting (65535*65535),
+// matching FIFTYONE_DEGREES_WEIGHTED_ITEM_MAX_WEIGHT in the C library. A raw
+// weighting is normalised against this to yield a 0.0-1.0 confidence.
+var maxWeighting = uint16Max * uint16Max
+
 // ResultsIpi represents a structure to manage IP-related results in the C library.
 // It contains a pointer to the C.ResultsIpi structure and a dynamic C result slice.
 type ResultsIpi struct {
@@ -129,11 +134,13 @@ func (r *ResultsIpi) getPropertyNameSafe(dataSet *C.DataSetIpi, requiredIndex C.
 	return ""
 }
 
-// header represents the structure holding type, required property index, and raw weighting for a weighted value.
+// header mirrors fiftyoneDegreesWeightedValueHeader from the C library. rawWeighting
+// is uint32_t in C (range 0-65535*65535); declaring it any narrower here truncates the
+// value to its low bytes and produces near-zero weights.
 type header struct {
 	valueType             C.fiftyoneDegreesPropertyValueType
 	requiredPropertyIndex C.int
-	rawWeighting          C.uint16_t
+	rawWeighting          C.uint32_t
 }
 
 // GetWeightedValuesByIndexes retrieves weighted values using pre-computed property indexes
@@ -230,14 +237,10 @@ func (r *ResultsIpi) GetWeightedValuesByIndexes(indexes []int, propertyNameResol
 			val = C.GoString(weightedString.value)
 		}
 
-		// append values to the map
-		// For MCC property, append with weight; for all others, append without weight
-		if propName == "Mcc" {
-			weight := float64(nextHeader.rawWeighting) / uint16Max
-			values.AppendWithWeight(propName, val, weight)
-		} else {
-			values.Append(propName, val)
-		}
+		// The C engine returns a confidence weighting for every value, not just Mcc.
+		// Surface it for all properties so callers can read per-value confidence.
+		weight := float64(nextHeader.rawWeighting) / maxWeighting
+		values.AppendWithWeight(propName, val, weight)
 	}
 
 	return values, nil

--- a/ipi_interop/weighted_value.go
+++ b/ipi_interop/weighted_value.go
@@ -21,8 +21,10 @@
  * ********************************************************************* */
 package ipi_interop
 
-// WeightedValue represents a value that may include a weight (used for MCC property).
-// For non-weighted properties, Weight will be 0.0.
+// WeightedValue represents a returned value together with its confidence weight
+// (0.0-1.0). Where a property resolves to a single value the weight is typically
+// 1.0; where an IP range resolves to several candidate values the weights reflect
+// each candidate's share.
 type WeightedValue struct {
 	Value  interface{}
 	Weight float64
@@ -32,7 +34,7 @@ type WeightedValue struct {
 type Values map[string][]*WeightedValue
 
 // GetValueByProperty retrieves the first value for the specified property (ignoring weight).
-// This is the recommended method for all properties except MCC.
+// Use GetValueWeightByProperty, or range over the property's slice, when the weight is needed.
 // Returns the value and a boolean indicating success or failure.
 func (v Values) GetValueByProperty(property string) (interface{}, bool) {
 	if val, ok := v[property]; ok && len(val) > 0 {
@@ -51,7 +53,7 @@ func (v Values) GetValueWeightByProperty(property string) (interface{}, float64,
 }
 
 // Append adds a value without weight (Weight will be set to 0.0).
-// Use this for all properties except MCC.
+// Prefer AppendWithWeight so the value's confidence weight is preserved.
 func (v Values) Append(property string, value interface{}) {
 	v[property] = append(v[property], &WeightedValue{
 		Value:  value,
@@ -59,8 +61,7 @@ func (v Values) Append(property string, value interface{}) {
 	})
 }
 
-// AppendWithWeight adds a value with a specific weight.
-// This should only be used for MCC property.
+// AppendWithWeight adds a value with its confidence weight (0.0-1.0).
 func (v Values) AppendWithWeight(property string, value interface{}, weight float64) {
 	v[property] = append(v[property], &WeightedValue{
 		Value:  value,


### PR DESCRIPTION
## Problem
Callers reading the weight of any property other than `Mcc` (e.g. `ConnectionType`, `IsBroadband`, `IsCellular`, `IsHosted`) always get `weight=0.00`, even though the engine computes a confidence weighting for every value. Reported by a trial customer via support.

Two distinct defects in `ipi_interop`:

1. **`GetWeightedValuesByIndexes` (`results_ipi.go`)** gated `AppendWithWeight` on `propName == "Mcc"` and appended every other property with `values.Append(...)`, which forces `Weight: 0.0`.
2. **The `header` struct** declared `rawWeighting` as `C.uint16_t`, but the C `fiftyoneDegreesWeightedValueHeader.rawWeighting` is `uint32_t` (max `65535*65535`). Reading it as `uint16_t` truncated the value to its low 16 bits, so even the `Mcc` path returned a near-zero weight (`0xFFFE0001 & 0xFFFF = 1` → `1/65535 ≈ 0`).

## Fix
- Read `rawWeighting` as `C.uint32_t` and normalise against `65535*65535` (matching `FIFTYONE_DEGREES_WEIGHTED_ITEM_MAX_WEIGHT`).
- Append the weight for **every** property, not just `Mcc`.
- Update the now-stale "MCC only" doc comments in `weighted_value.go`.

## Validation
Built with `CGO_ENABLED=1` against an Enterprise `.ipi` file and ran the customer's 3 sample IPs with an explicit property list `[ConnectionType, IsBroadband, IsCellular, IsHosted]`:

| | before | after |
|---|---|---|
| weight for all 12 value/property pairs | `0.0000` | `1.0000` (single-value results) |

`go build` and `go vet` pass on `./ipi_interop/...`.