### PR TITLE
Guard reloadManager published-date log against a failed load

### DIFF
--- a/ipi_onpremise/onpremise.go
+++ b/ipi_onpremise/onpremise.go
@@ -270,12 +270,17 @@ func (e *Engine) processFileExternallyChanged() error {
 // this function will be called when the engine is started or the is new file available
 // it will create and initialize a new manager from the new file if it does not exist
 // if the manager exists, it will create a new manager from the new file and replace the existing manager thus freeing memory of the old manager
-func (e *Engine) reloadManager(filePath string) error {
+func (e *Engine) reloadManager(filePath string) (err error) {
 	if e.isStopped {
 		return nil
 	}
-	// if manager is nil, create a new one
+	// Log the published date only once the (re)load succeeded. On a failed load the
+	// dataset is not attached to the manager, so getPublishedDate would dereference a
+	// null dataset and segfault - the deferred log must not run on the error paths.
 	defer func() {
+		if err != nil {
+			return
+		}
 		year, month, day := e.getPublishedDate().Date()
 		e.logger.Printf("data file loaded from " + filePath + " published on: " + fmt.Sprintf("%d-%d-%d", year, month, day))
 	}()
@@ -301,7 +306,7 @@ func (e *Engine) reloadManager(filePath string) error {
 		return nil
 	}
 
-	err := e.manager.ReloadFromFile(*e.config, strings.Join(e.managerProperties, ","), filePath)
+	err = e.manager.ReloadFromFile(*e.config, strings.Join(e.managerProperties, ","), filePath)
 	if err != nil {
 		return fmt.Errorf("failed to reload manager from file: %w", err)
 	}


### PR DESCRIPTION
## Problem
`Engine.reloadManager` (`ipi_onpremise/onpremise.go`) defers a `getPublishedDate()` call that runs on **every** return path, including when `InitManagerFromFile` returns an error. On a failed load the dataset is never attached to the manager, so `GetPublishedDate` dereferences a null dataset (`cDataSet.header.published`) and segfaults - masking the real init error.

Reported by a trial customer: an older library version could not load a newer data file, silently failed init, then segfaulted in `getPublishedDate` via this deferred call. The latent bug is still present on `main` (a successful load just never hits the null path).

## Fix
Use a named return and skip the deferred published-date log when the (re)load returned an error, so the underlying init/reload error propagates cleanly instead of crashing the process.

## Validation
`go build`, `go vet`, and `go test ./ipi_onpremise/...` pass.