### PR TITLE
Weight IPI values by property type; unweighted properties report full confidence

### DIFF
--- a/ipi_interop/results_ipi.go
+++ b/ipi_interop/results_ipi.go
@@ -34,6 +34,13 @@ import (
 // uint16Max represents the maximum value of a uint16 converted to a float64.
 var uint16Max = float64(C.UINT16_MAX)
 
+// maxWeighting is the maximum value of a header's rawWeighting (65535*65535),
+// matching FIFTYONE_DEGREES_WEIGHTED_ITEM_MAX_WEIGHT in the C library. A raw
+// weighting is normalised against this to yield a 0.0-1.0 confidence. The raw
+// value is profileGroupWeight*valueWeight, so a value that fills its matched IP
+// range reaches this maximum.
+var maxWeighting = uint16Max * uint16Max
+
 // ResultsIpi represents a structure to manage IP-related results in the C library.
 // It contains a pointer to the C.ResultsIpi structure and a dynamic C result slice.
 type ResultsIpi struct {
@@ -129,11 +136,35 @@ func (r *ResultsIpi) getPropertyNameSafe(dataSet *C.DataSetIpi, requiredIndex C.
 	return ""
 }
 
-// header represents the structure holding type, required property index, and raw weighting for a weighted value.
+// isPropertyWeighted reports whether the property at the given required index has
+// a weighted value type - i.e. its values carry an intrinsic per-value confidence
+// weight (Mcc and the multi-value location lists). It resolves the required index
+// to the property in the source collection and reads that property's declared
+// value type. On any failure it returns false so the value is treated as
+// unweighted rather than reporting a spurious weight.
+func (r *ResultsIpi) isPropertyWeighted(dataSet *C.DataSetIpi, requiredIndex C.int, exception *Exception) bool {
+	propertyIndex := C.fiftyoneDegreesPropertiesGetPropertyIndexFromRequiredIndex(
+		dataSet.b.b.available, requiredIndex)
+	if propertyIndex < 0 {
+		return false
+	}
+
+	valueType := C.fiftyoneDegreesPropertyGetValueType(
+		dataSet.properties, C.uint32_t(propertyIndex), exception.CPtr)
+	if !exception.IsOkay() {
+		return false
+	}
+
+	return PropertyValueType(valueType).IsWeighted()
+}
+
+// header mirrors fiftyoneDegreesWeightedValueHeader from the C library. rawWeighting
+// is uint32_t in C (range 0-65535*65535); declaring it any narrower here truncates the
+// value to its low bytes and produces near-zero weights.
 type header struct {
 	valueType             C.fiftyoneDegreesPropertyValueType
 	requiredPropertyIndex C.int
-	rawWeighting          C.uint16_t
+	rawWeighting          C.uint32_t
 }
 
 // GetWeightedValuesByIndexes retrieves weighted values using pre-computed property indexes
@@ -180,6 +211,12 @@ func (r *ResultsIpi) GetWeightedValuesByIndexes(indexes []int, propertyNameResol
 	defer C.fiftyoneDegreesWeightedValuesCollectionRelease(&collection)
 
 	values := make(Values, collection.itemsCount)
+
+	// Cache the weighted/unweighted decision per required-property index so the
+	// value-type lookup runs once per property rather than once per value.
+	weightedByReqIndex := make(map[C.int]bool)
+	typeException := NewException()
+	defer typeException.Free()
 
 	// Create a Go slice from the C array
 	headers := unsafe.Slice(collection.items, collection.itemsCount)
@@ -230,14 +267,21 @@ func (r *ResultsIpi) GetWeightedValuesByIndexes(indexes []int, propertyNameResol
 			val = C.GoString(weightedString.value)
 		}
 
-		// append values to the map
-		// For MCC property, append with weight; for all others, append without weight
-		if propName == "Mcc" {
-			weight := float64(nextHeader.rawWeighting) / uint16Max
-			values.AppendWithWeight(propName, val, weight)
-		} else {
-			values.Append(propName, val)
+		// Weighted properties (e.g. Mcc and the multi-value location lists) carry an
+		// intrinsic per-value weight, so surface their real confidence. Every other
+		// property is unweighted: report full confidence (1.0) rather than 0.0, which
+		// reads as zero confidence.
+		weighted, seen := weightedByReqIndex[requiredPropertyIndex]
+		if !seen {
+			weighted = r.isPropertyWeighted(dataSet, requiredPropertyIndex, typeException)
+			weightedByReqIndex[requiredPropertyIndex] = weighted
 		}
+
+		weight := 1.0
+		if weighted {
+			weight = float64(nextHeader.rawWeighting) / maxWeighting
+		}
+		values.AppendWithWeight(propName, val, weight)
 	}
 
 	return values, nil

--- a/ipi_interop/value_types.go
+++ b/ipi_interop/value_types.go
@@ -43,5 +43,20 @@ const (
 	DeclinationValueType                          // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_DECLINATION
 	AzimuthValueType                              // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_AZIMUTH
 	WkbRValueType                                 // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WKB_R
-
+	WeightedStringValueType                       // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_STRING
+	WeightedIntValueType                          // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_INT
+	WeightedDoubleValueType                       // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_DOUBLE
+	WeightedBoolValueType                         // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_BOOL
+	WeightedSingleValueType                       // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_SINGLE
+	WeightedByteValueType                         // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_BYTE
+	WeightedIpAddressValueType                    // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_IP_ADDRESS
+	WeightedWkbRValueType                         // FIFTYONE_DEGREES_PROPERTY_VALUE_TYPE_WEIGHTED_WKB_R
 )
+
+// IsWeighted reports whether the property value type is a weighted list type,
+// meaning its values carry an intrinsic per-value confidence weight (e.g. Mcc,
+// which is WeightedString). Non-weighted properties are single, deterministic
+// values with no meaningful per-value weight.
+func (t PropertyValueType) IsWeighted() bool {
+	return t >= WeightedStringValueType && t <= WeightedWkbRValueType
+}

--- a/ipi_interop/weighted_value.go
+++ b/ipi_interop/weighted_value.go
@@ -21,8 +21,10 @@
  * ********************************************************************* */
 package ipi_interop
 
-// WeightedValue represents a value that may include a weight (used for MCC property).
-// For non-weighted properties, Weight will be 0.0.
+// WeightedValue represents a returned value together with its confidence weight
+// (0.0-1.0). Unweighted properties report a weight of 1.0 (full confidence).
+// Weighted properties (whose values carry an intrinsic weight, e.g. Mcc and the
+// multi-value location lists) report each value's share of the matched IP range.
 type WeightedValue struct {
 	Value  interface{}
 	Weight float64
@@ -32,7 +34,7 @@ type WeightedValue struct {
 type Values map[string][]*WeightedValue
 
 // GetValueByProperty retrieves the first value for the specified property (ignoring weight).
-// This is the recommended method for all properties except MCC.
+// Use GetValueWeightByProperty, or range over the property's slice, when the weight is needed.
 // Returns the value and a boolean indicating success or failure.
 func (v Values) GetValueByProperty(property string) (interface{}, bool) {
 	if val, ok := v[property]; ok && len(val) > 0 {
@@ -51,7 +53,7 @@ func (v Values) GetValueWeightByProperty(property string) (interface{}, float64,
 }
 
 // Append adds a value without weight (Weight will be set to 0.0).
-// Use this for all properties except MCC.
+// Prefer AppendWithWeight so the value's confidence weight is preserved.
 func (v Values) Append(property string, value interface{}) {
 	v[property] = append(v[property], &WeightedValue{
 		Value:  value,
@@ -59,8 +61,7 @@ func (v Values) Append(property string, value interface{}) {
 	})
 }
 
-// AppendWithWeight adds a value with a specific weight.
-// This should only be used for MCC property.
+// AppendWithWeight adds a value with its confidence weight (0.0-1.0).
 func (v Values) AppendWithWeight(property string, value interface{}, weight float64) {
 	v[property] = append(v[property], &WeightedValue{
 		Value:  value,


### PR DESCRIPTION
## Background
A trial customer reported `weight=0.00` for `ConnectionType`, `IsBroadband`, `IsCellular`, `IsHosted`. Per `common-metadata`, only *weighted-type* properties carry an intrinsic per-value confidence: `Mcc` (WeightedString) and the multi-value location lists (`CountryCodesGeographical`, `CountryCodesPopulation`, `CountryNames*Translated`). Every other IPI property is single-valued and unweighted. The wrapper had three problems:

1. It reported `weight=0.0` for unweighted properties, which reads as *zero confidence* rather than *not weighted*.
2. It decided weighted-ness with a hardcoded `propName == "Mcc"` check, so the weighted location lists never got real weights.
3. It read `rawWeighting` as `C.uint16_t`, but the C field is `uint32_t`, so weights were truncated to near-zero even when computed.

## Changes
- **Fix `rawWeighting` truncation.** `header.rawWeighting` is now `C.uint32_t` (matching `fiftyoneDegreesWeightedValueHeader`, max `65535*65535`) and normalised against that max. Read as 16-bit it truncated to the low bytes (`0xFFFE0001 & 0xFFFF = 1` -> `~0.0`).
- **Detect weighted-ness from metadata.** Map the required-property index to its property (`PropertiesGetPropertyIndexFromRequiredIndex`) and read the declared value type (`PropertyGetValueType`); a value type in the `WEIGHTED_*` range (enum 14-21) is weighted. Added the weighted `PropertyValueType` constants and an `IsWeighted()` helper. The per-property decision is cached per required-property index so the lookup runs once per property, not once per value.
- **Report `1.0` for unweighted properties** and the real normalised weight for weighted ones.

Non-breaking: the `Values` / `WeightedValue` types and accessors are unchanged.

## Validation
Built with `CGO_ENABLED=1` and run against an Enterprise `.ipi` file:

| property | before | after |
|---|---|---|
| ConnectionType / IsBroadband / IsCellular / IsHosted | `0.0000` | `1.0000` |
| Mcc (single-value result) | `~0.0000` (truncated) | `1.0000` |
| CountryCodesGeographical / CountryCodesPopulation (multi-value) | `0.0000` each | real split, e.g. `SE 0.9203, NO 0.0461, FI 0.0295, AX 0.0021, DK 0.0020` (sums to 1.0) |

`go build` and `go vet ./ipi_interop/...` pass.